### PR TITLE
source.extension.vsixmanifest: Fixed missing closing '>'

### DIFF
--- a/EditorConfigGuidelines/source.extension.vsixmanifest
+++ b/EditorConfigGuidelines/source.extension.vsixmanifest
@@ -15,7 +15,7 @@
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
             <ProductArchitecture>arm64</ProductArchitecture>
         </InstallationTarget>
-    </Installation
+    </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>


### PR DESCRIPTION
The '>' in the closing </Installation> tag was missing.